### PR TITLE
Port tooling from JBS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>47</version>
+    </parent>
+
+    <groupId>org.jboss.pnc</groupId>
+    <artifactId>konflux-tooling</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <name>Konflux Java Tooling</name>
+    <description>PNC Java Tooling for Konflux</description>
+    <url>https://github.com/project-ncl/konflux-tooling</url>
+    <scm>
+        <connection>scm:git:https://github.com/project-ncl/konflux-tooling.git</connection>
+        <developerConnection>scm:git:git@github.com:project-ncl/konflux-tooling.git</developerConnection>
+        <url>https://github.com/project-ncl/konflux-tooling</url>
+        <tag>HEAD</tag>
+    </scm>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>rnc</id>
+            <name>Nick Cross</name>
+            <email>ncross@redhat.com</email>
+        </developer>
+    </developers>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <jboss.releases.repo.id>sonatype-nexus-staging</jboss.releases.repo.id>
+        <jboss.releases.repo.url>https://oss.sonatype.org/service/local/staging/deploy/maven2</jboss.releases.repo.url>
+        <jboss.snapshots.repo.id>sonatype-nexus-snapshots</jboss.snapshots.repo.id>
+        <jboss.snapshots.repo.url>https://oss.sonatype.org/content/repositories/snapshots</jboss.snapshots.repo.url>
+
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.17.3</quarkus.platform.version>
+
+        <lombok.version>1.18.32</lombok.version>
+        <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
+        <impsort-maven-plugin.version>1.12.0</impsort-maven-plugin.version>
+
+        <format.skip>false</format.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-picocli</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkiverse.mavenresolver</groupId>
+            <artifactId>quarkus-maven-resolver</artifactId>
+            <version>0.0.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.indexer</groupId>
+            <artifactId>indexer-core</artifactId>
+            <version>7.1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.pnc</groupId>
+            <artifactId>pnc-api</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.16.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>3.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <version>${formatter-maven-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-ide-config</artifactId>
+                        <version>${quarkus.platform.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <!-- store outside of target to speed up formatting when mvn clean is used -->
+                    <cachedir>.cache/formatter-maven-plugin-${formatter-maven-plugin.version}</cachedir>
+                    <configFile>eclipse-format.xml</configFile>
+                    <lineEnding>LF</lineEnding>
+                    <skip>${format.skip}</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code</groupId>
+                <artifactId>impsort-maven-plugin</artifactId>
+                <version>${impsort-maven-plugin.version}</version>
+                <configuration>
+                    <!-- store outside of target to speed up formatting when mvn clean is used -->
+                    <cachedir>.cache/impsort-maven-plugin-${impsort-maven-plugin.version}</cachedir>
+                    <groups>java.,javax.,jakarta.,org.,com.</groups>
+                    <staticGroups>*</staticGroups>
+                    <lineEnding>LF</lineEnding>
+                    <skip>${format.skip}</skip>
+                    <removeUnused>true</removeUnused>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+        </profile>
+        <profile>
+            <id>format</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!validate-format</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.revelc.code.formatter</groupId>
+                        <artifactId>formatter-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>format</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.revelc.code</groupId>
+                        <artifactId>impsort-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sort-imports</id>
+                                <goals>
+                                    <goal>sort</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>validate</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>validate-format</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.revelc.code.formatter</groupId>
+                        <artifactId>formatter-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>validate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.revelc.code</groupId>
+                        <artifactId>impsort-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>check-imports</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/src/main/docker/Dockerfile.all-in-one
+++ b/src/main/docker/Dockerfile.all-in-one
@@ -1,0 +1,25 @@
+FROM registry.access.redhat.com/ubi8/openjdk-21@sha256:5ab904e6262629fca79d6f65fa859bfa376405522d2f660bdbfaaae2742586f1 AS builder
+
+USER root
+RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y git
+
+USER 185
+WORKDIR /work
+COPY ./ .
+
+RUN mvn -V -B package -DskipTests
+
+FROM registry.access.redhat.com/ubi8/openjdk-21-runtime@sha256:0a8cf41082f11f5bc56bd9438851e54593e17051df49592e953fb59376c7d539
+WORKDIR /work/
+
+COPY --from=builder /work/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=builder /work/target/quarkus-app/*.jar /deployments/
+COPY --from=builder /work/target/quarkus-app/app/ /deployments/app/
+COPY --from=builder /work/target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER 185
+
+ENV AB_JOLOKIA_OFF=""
+ENV JAVA_OPTS="-Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/src/main/java/org/jboss/pnc/konfluxtooling/EntryPoint.java
+++ b/src/main/java/org/jboss/pnc/konfluxtooling/EntryPoint.java
@@ -1,0 +1,19 @@
+package org.jboss.pnc.konfluxtooling;
+
+import org.jboss.pnc.konfluxtooling.deploy.CopyArtifactsCommand;
+import org.jboss.pnc.konfluxtooling.deploy.DeployCommand;
+import org.jboss.pnc.konfluxtooling.notification.NotifyCommand;
+import org.jboss.pnc.konfluxtooling.prebuild.Preprocessor;
+
+import io.quarkus.picocli.runtime.annotations.TopCommand;
+import picocli.CommandLine;
+
+@TopCommand
+@CommandLine.Command(mixinStandardHelpOptions = true, subcommands = {
+        CopyArtifactsCommand.class,
+        DeployCommand.class,
+        NotifyCommand.class,
+        Preprocessor.class
+})
+public class EntryPoint {
+}

--- a/src/main/java/org/jboss/pnc/konfluxtooling/ResultsUpdater.java
+++ b/src/main/java/org/jboss/pnc/konfluxtooling/ResultsUpdater.java
@@ -1,0 +1,30 @@
+package org.jboss.pnc.konfluxtooling;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+public class ResultsUpdater {
+
+    public static ObjectMapper MAPPER = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+    public void updateResults(Map<String, String> results) {
+
+        for (var e : results.entrySet()) {
+            try {
+                Files.writeString(Paths.get("/tekton/results", e.getKey()), e.getValue());
+            } catch (IOException ex) {
+                Log.errorf(ex, "Failed to write result %s", e.getKey());
+            }
+        }
+    }
+}

--- a/src/main/java/org/jboss/pnc/konfluxtooling/deploy/CopyArtifactsCommand.java
+++ b/src/main/java/org/jboss/pnc/konfluxtooling/deploy/CopyArtifactsCommand.java
@@ -1,0 +1,142 @@
+package org.jboss.pnc.konfluxtooling.deploy;
+
+import static java.nio.file.StandardCopyOption.COPY_ATTRIBUTES;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.apache.commons.io.FilenameUtils.removeExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import org.apache.maven.index.artifact.Gav;
+import org.apache.maven.index.artifact.M2GavCalculator;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import io.quarkus.logging.Log;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(name = "copy-artifacts")
+public class CopyArtifactsCommand implements Runnable {
+    @Option(required = true, names = { "-s", "--source-path" })
+    Path sourcePath;
+
+    @Option(required = true, names = { "-d", "--deploy-path" })
+    Path deployPath;
+
+    @Override
+    public void run() {
+        if (Files.isDirectory(deployPath)) {
+            Log.warnf("Skipping copy artifacts since deploy path %s already exists", deployPath);
+            return;
+        }
+
+        var pomFiles = new HashMap<Gav, Path>();
+        var jarFiles = new ArrayList<Path>();
+
+        try (var stream = Files.walk(sourcePath)) {
+            stream.forEach(path -> {
+                if (Files.isRegularFile(path)) {
+                    var fileName = path.getFileName().toString();
+
+                    if (fileName.endsWith(".pom") || fileName.equals("pom.xml")) {
+                        try (var pomReader = Files.newBufferedReader(path)) {
+                            var project = new MavenProject(new MavenXpp3Reader().read(pomReader));
+                            var version = project.getVersion();
+
+                            if (version.endsWith("@") || version.endsWith("-SNAPSHOT")) {
+                                Log.warnf("Skipping POM %s with invalid version %s", fileName, version);
+                            } else {
+                                var packaging = project.getPackaging();
+                                var gav = new Gav(project.getGroupId(), project.getArtifactId(), version, null, packaging, null,
+                                        null, null, false, null, false, null);
+
+                                var existingPath = pomFiles.get(gav);
+
+                                if (existingPath == null) {
+                                    pomFiles.put(gav, path);
+                                } else {
+                                    var existingFileName = existingPath.getFileName().toString();
+
+                                    // If multiple POM files are found, prefer the one named -<version>.pom
+                                    if (existingFileName.equals("pom.xml")
+                                            || !existingFileName.endsWith("-" + gav.getVersion() + ".pom")) {
+                                        pomFiles.put(gav, path);
+                                    }
+                                }
+                            }
+                        } catch (IOException | XmlPullParserException e) {
+                            throw new RuntimeException(e);
+                        }
+                    } else if (fileName.endsWith(".jar")) {
+                        jarFiles.add(path);
+                    }
+                }
+            });
+
+            Log.infof("Found %d POMs and %d JARs in %s", pomFiles.size(), jarFiles.size(), sourcePath);
+
+            for (var entry : pomFiles.entrySet()) {
+                var gav = entry.getKey();
+                Log.debugf("POM has GAV %s", gavToCoords(gav));
+                var pathExt = new M2GavCalculator().gavToPath(gav).substring(1);
+                var path = removeExtension(pathExt);
+                var repoPath = Path.of(path);
+                var fullPath = deployPath.resolve(repoPath);
+                Log.debugf("Deploying to path %s", repoPath);
+                var pomDestFile = Path.of(fullPath + ".pom");
+                if (Files.exists(pomDestFile)) {
+                    continue;
+                }
+                Files.createDirectories(fullPath.getParent());
+                var pomSourceFile = entry.getValue();
+                Log.infof("Copying %s to %s", pomSourceFile, pomDestFile);
+                Files.copy(pomSourceFile, pomDestFile, REPLACE_EXISTING, COPY_ATTRIBUTES);
+                var packaging = gav.getExtension();
+
+                if (!packaging.equals("jar")) {
+                    continue;
+                }
+
+                var jarDestFile = Path.of(fullPath + ".jar");
+                var jarName = jarDestFile.getFileName().toString();
+                var files = jarFiles.stream().filter(jarPath -> jarPath.getFileName().toString().equals(jarName)).toList();
+                var jarSourceFile = (Path) null;
+
+                if (!files.isEmpty()) {
+                    jarSourceFile = files.get(0);
+                } else {
+                    var unversionedJarName = jarName.replace("-" + gav.getVersion(), "");
+                    files = jarFiles.stream().filter(jarPath -> jarPath.getFileName().toString().equals(unversionedJarName))
+                            .toList();
+
+                    if (!files.isEmpty()) {
+                        jarSourceFile = files.get(0);
+                    }
+                }
+
+                if (jarSourceFile != null) {
+                    Log.infof("Copying %s to %s", jarSourceFile, jarDestFile);
+                    Files.copy(jarSourceFile, jarDestFile, REPLACE_EXISTING, COPY_ATTRIBUTES);
+                } else {
+                    throw new RuntimeException("Could not find candidate for " + jarName + " in " + jarFiles);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String gavToCoords(Gav gav) {
+        var groupId = gav.getGroupId();
+        var artifactId = gav.getArtifactId();
+        var extension = gav.getExtension() != null ? ":" + gav.getExtension() : "";
+        var classifier = gav.getClassifier() != null ? ":" + gav.getClassifier() : "";
+        var version = gav.getVersion();
+        return groupId + ":" + artifactId + extension + classifier + ":" + version;
+    }
+}

--- a/src/main/java/org/jboss/pnc/konfluxtooling/deploy/DeployCommand.java
+++ b/src/main/java/org/jboss/pnc/konfluxtooling/deploy/DeployCommand.java
@@ -1,0 +1,101 @@
+package org.jboss.pnc.konfluxtooling.deploy;
+
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
+import io.quarkus.logging.Log;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "deploy")
+public class DeployCommand implements Runnable {
+
+    @CommandLine.Option(names = "--directory", required = true)
+    String artifactDirectory;
+
+    // Maven Repo Deployment specification
+    @CommandLine.Option(names = "--mvn-username")
+    String mvnUser;
+
+    @ConfigProperty(name = "access.token")
+    Optional<String> accessToken;
+
+    @ConfigProperty(name = "maven.password")
+    Optional<String> mvnPassword;
+
+    @CommandLine.Option(names = "--mvn-settings")
+    String mvnSettings;
+
+    @CommandLine.Option(names = "--mvn-repo", required = true)
+    String mvnRepo;
+
+    @CommandLine.Option(names = "--server-id")
+    String serverId = "indy-mvn";
+
+    @Inject
+    BootstrapMavenContext mvnCtx;
+
+    public void run() {
+        try {
+            var deploymentPath = Path.of(artifactDirectory);
+
+            if (!deploymentPath.toFile().exists()) {
+                Log.warnf("No deployed artifacts found. Has the build been correctly configured to deploy?");
+                throw new RuntimeException("Deploy failed");
+            }
+            if (isNotEmpty(mvnSettings)) {
+                if (!Path.of(mvnSettings).toFile().exists()) {
+                    Log.errorf("Invalid Maven settings path: %s", mvnSettings);
+                    throw new RuntimeException("Invalid Maven settings");
+                }
+                System.setProperty("maven.settings", mvnSettings);
+            }
+            if (accessToken.isPresent()) {
+                String servers = """
+                        <settings>
+                            <!--
+                                Needed for Maven 3.9+. Switched to native resolver
+                                https://maven.apache.org/guides/mini/guide-resolver-transport.html
+                            -->
+                            <servers>
+                                <server>
+                                    <id>indy-mvn</id>
+                                    <configuration>
+                                        <connectionTimeout>60000</connectionTimeout>
+                                        <httpHeaders>
+                                            <property>
+                                                <name>Authorization</name>
+                                                <value>Bearer ${ACCESS_TOKEN}</value>
+                                            </property>
+                                        </httpHeaders>
+                                    </configuration>
+                                </server>
+                            </servers>
+                        </settings>
+                        """;
+                if (isNotEmpty(mvnSettings)) {
+                    // TODO: Would need to merge the two files. NYI for now as I don't think we need this pattern
+                    throw new RuntimeException("Merging settings.xml not supported");
+                } else {
+                    Path settings = Path.of(deploymentPath.getParent().toString(), "settings.xml");
+                    Files.write(settings, servers.getBytes());
+                    System.setProperty("maven.settings", settings.toString());
+                }
+            }
+            // Maven Repo Deployment
+            MavenRepositoryDeployer deployer = new MavenRepositoryDeployer(mvnCtx, mvnUser, mvnPassword.orElse(""), mvnRepo,
+                    serverId, deploymentPath);
+            deployer.deploy();
+        } catch (Exception e) {
+            Log.error("Deployment failed", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/org/jboss/pnc/konfluxtooling/deploy/MavenRepositoryDeployer.java
+++ b/src/main/java/org/jboss/pnc/konfluxtooling/deploy/MavenRepositoryDeployer.java
@@ -1,0 +1,140 @@
+package org.jboss.pnc.konfluxtooling.deploy;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.deployment.DeployRequest;
+import org.eclipse.aether.deployment.DeploymentException;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
+
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.logging.Log;
+
+public class MavenRepositoryDeployer {
+    private final String username;
+
+    private final String password;
+
+    private final String repository;
+
+    private final Path artifacts;
+
+    private final RepositorySystem system;
+
+    private final RepositorySystemSession session;
+
+    private final String serverId;
+
+    public MavenRepositoryDeployer(BootstrapMavenContext mvnCtx, String username, String password, String repository,
+            String serverId, Path artifacts)
+            throws BootstrapMavenException {
+        this.username = username;
+        this.password = password;
+        this.repository = repository;
+        this.artifacts = artifacts;
+        this.serverId = serverId;
+
+        this.system = mvnCtx.getRepositorySystem();
+        // Note - we were using MavenRepositorySystemUtils.newSession but that doesn't correctly process
+        //  the settings.xml without an active project.
+        this.session = mvnCtx.getRepositorySystemSession();
+    }
+
+    public void deploy()
+            throws IOException {
+        RemoteRepository result;
+        RemoteRepository initial = new RemoteRepository.Builder(serverId,
+                "default",
+                repository).build();
+        RemoteRepository.Builder builder = new RemoteRepository.Builder(initial);
+
+        if (isNotEmpty(username)) {
+            builder.setAuthentication(new AuthenticationBuilder().addUsername(username)
+                    .addPassword(password).build());
+        } else {
+            builder.setAuthentication(session.getAuthenticationSelector().getAuthentication(initial));
+        }
+        if (initial.getProxy() == null) {
+            builder.setProxy(session.getProxySelector().getProxy(initial));
+        }
+        result = builder.build();
+
+        Log.infof("Configured repository %s", result);
+
+        Files.walkFileTree(artifacts,
+                new SimpleFileVisitor<>() {
+
+                    @Override
+                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                            throws IOException {
+                        try (var stream = Files.list(dir)) {
+                            List<Path> files = stream.sorted().toList();
+                            boolean hasPom = files.stream().anyMatch(s -> s.toString().endsWith(".pom"));
+                            if (hasPom) {
+                                Path relative = artifacts.relativize(dir);
+                                if (relative.getNameCount() <= 2) {
+                                    Log.errorf(
+                                            "Invalid repository format. Local directory is '%s' with relative path '%s' and not enough components to calculate groupId and artifactId",
+                                            artifacts, relative);
+                                }
+                                // If we're in org/foobar/artifact/1.0 then the group is two up and the artifact is one up.
+                                String group = relative.getParent().getParent().toString().replace(File.separatorChar,
+                                        '.');
+                                String artifact = relative.getParent().getFileName().toString();
+                                String version = dir.getFileName().toString();
+                                Log.info(
+                                        "GROUP: " + group + " , ARTIFACT:" + artifact + " , VERSION: "
+                                                + version);
+                                Pattern p = Pattern
+                                        .compile(artifact + "-" + version + "(-(\\w+))?\\.(\\w+)");
+                                DeployRequest deployRequest = new DeployRequest();
+                                deployRequest.setRepository(result);
+                                for (var i : files) {
+                                    Matcher matcher = p.matcher(i.getFileName().toString());
+                                    if (matcher.matches()) {
+                                        Artifact jarArtifact = new DefaultArtifact(group, artifact,
+                                                matcher.group(2),
+                                                matcher.group(3),
+                                                version);
+                                        Log.infof("Uploading %s", jarArtifact);
+                                        jarArtifact = jarArtifact.setFile(i.toFile());
+                                        deployRequest.addArtifact(jarArtifact);
+                                    }
+                                }
+
+                                try {
+                                    Log.infof("Deploying %s", deployRequest);
+                                    system.deploy(session, deployRequest);
+                                } catch (DeploymentException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            } else {
+                                var filtered = files.stream().filter(f -> !f.toFile().isDirectory()).toList();
+                                if (!filtered.isEmpty()) {
+                                    Log.warnf("For directory %s, no pom file found with files %s", dir, filtered);
+                                }
+                            }
+
+                            return FileVisitResult.CONTINUE;
+                        }
+                    }
+
+                });
+    }
+}

--- a/src/main/java/org/jboss/pnc/konfluxtooling/notification/NotifyCommand.java
+++ b/src/main/java/org/jboss/pnc/konfluxtooling/notification/NotifyCommand.java
@@ -1,0 +1,77 @@
+package org.jboss.pnc.konfluxtooling.notification;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Optional;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.pnc.api.dto.Request;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.logging.Log;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "notify")
+public class NotifyCommand implements Runnable {
+
+    @CommandLine.Option(names = "--build-id", required = true)
+    String buildId;
+
+    @CommandLine.Option(names = "--status", required = true)
+    String status;
+
+    @CommandLine.Option(names = "--context", required = true)
+    String context;
+
+    @CommandLine.Option(names = "--request-timeout")
+    int requestTimeout = 15;
+
+    // TODO: do we need this...
+    @ConfigProperty(name = "access.token")
+    Optional<String> accessToken;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    public void run() {
+        try {
+
+            if (isEmpty(context)) {
+                Log.infof("No callback configured ; unable to notify.");
+                return;
+            }
+
+            Request callback = objectMapper.readValue(context, Request.class);
+
+            Log.infof("Notification for build %s with status %s and callback %s", buildId, status, callback);
+            PipelineNotification notification = PipelineNotification.builder().buildId(buildId).status(status)
+                    .completionCallback((Request) callback.getAttachment()).build();
+            String body = objectMapper.writeValueAsString(notification);
+
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(callback.getUri())
+                    .method(callback.getMethod().name(), HttpRequest.BodyPublishers.ofString(body))
+                    .timeout(Duration.ofSeconds(requestTimeout));
+            callback.getHeaders().forEach(h -> builder.header(h.getName(), h.getValue()));
+
+            HttpRequest request = builder.build();
+            // TODO: Retry? Send async? Some useful mutiny examples from quarkus in https://gist.github.com/cescoffier/e9abce907a1c3d05d70bea3dae6dc3d5
+            HttpResponse<String> response;
+            try (HttpClient httpClient = HttpClient.newHttpClient()) {
+                response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            }
+            Log.infof("Response %s", response);
+
+        } catch (Exception e) {
+            Log.error("Notification failed", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/org/jboss/pnc/konfluxtooling/notification/PipelineNotification.java
+++ b/src/main/java/org/jboss/pnc/konfluxtooling/notification/PipelineNotification.java
@@ -1,0 +1,19 @@
+package org.jboss.pnc.konfluxtooling.notification;
+
+import org.jboss.pnc.api.dto.Request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Builder;
+
+// TODO: This is a direct copy of the same class in konflux-build-driver. Both need moved to pnc-api to
+//      avoid clashes and duplication. For instance, we can't depend upon konflux-build-driver as that
+//      then leads to oidc client issues.
+@Builder(builderClassName = "Builder")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PipelineNotification(
+        String status,
+        String buildId,
+        Request completionCallback) {
+
+}

--- a/src/main/java/org/jboss/pnc/konfluxtooling/prebuild/Preprocessor.java
+++ b/src/main/java/org/jboss/pnc/konfluxtooling/prebuild/Preprocessor.java
@@ -1,0 +1,447 @@
+package org.jboss.pnc.konfluxtooling.prebuild;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import io.quarkus.logging.Log;
+import picocli.CommandLine;
+
+/**
+ * We keep all the options the same between maven, gradle, sbt and ant for now to keep the pipeline setup simpler.
+ * Some of these may be ignored by different processors
+ */
+@CommandLine.Command(name = "prepare")
+public class Preprocessor implements Runnable {
+
+    /**
+     * Equivalent to <code>$(workspaces.source.path)/source</code>
+     * $(workspaces.source.path) = /var/workdir/workspace
+     */
+    @CommandLine.Parameters(description = "The directory to process")
+    Path buildRoot;
+
+    @CommandLine.Option(names = "--recipe-image", required = true)
+    String recipeImage;
+
+    @CommandLine.Option(names = "--request-processor-image", required = true)
+    String buildRequestProcessorImage;
+
+    @CommandLine.Option(names = "--java-version", required = true)
+    String javaVersion;
+
+    @CommandLine.Option(names = "--build-tool-version", required = true)
+    String buildToolVersion;
+
+    @CommandLine.Option(names = "--type", required = true)
+    ToolType type;
+
+    protected enum ToolType {
+        ANT,
+        GRADLE,
+        MAVEN,
+        SBT;
+
+        @Override
+        public String toString() {
+            return name().toLowerCase();
+        }
+    }
+
+    /**
+     * This section creates two files within a <code>.jbs</code> subdirectory. The Containerfile is used
+     * by Konflux to initiate a build and the <code>run-build.sh</code> contains generic setup
+     * ( e.g. PATHs, directories, Maven Settings, etc) to which is appended the user build script for the main
+     * build.
+     */
+    @Override
+    public void run() {
+        Path jbsDirectory = Path.of(buildRoot.toString(), ".jbs");
+        //noinspection ResultOfMethodCallIgnored
+        jbsDirectory.toFile().mkdirs();
+
+        String buildScript = System.getenv("BUILD_SCRIPT");
+        if (isEmpty(buildScript)) {
+            Log.errorf("Unable to find BUILD_SCRIPT in environment");
+        }
+
+        Log.warnf("### Using tool %s with version %s and javaHome %s", type, buildToolVersion, javaVersion);
+
+        String javaHome;
+        if (javaVersion.equals("7") || javaVersion.equals("8")) {
+            javaHome = "/lib/jvm/java-1." + javaVersion + ".0";
+        } else {
+            javaHome = "/lib/jvm/java-" + javaVersion;
+        }
+
+        String runBuild = """
+                #!/usr/bin/env bash
+                set -o verbose
+                set -o pipefail
+                set -e
+
+                #fix this when we no longer need to run as root
+                export HOME=${HOME:=/root}
+                # Custom base working directory.
+                export JBS_WORKDIR=${JBS_WORKDIR:=/var/workdir/workspace}
+
+                export LANG="en_US.UTF-8"
+                export LC_ALL="en_US.UTF-8"
+                export JAVA_HOME=${JAVA_HOME:=%s}
+                # If we run out of memory we want the JVM to die with error code 134
+                export MAVEN_OPTS="-XX:+CrashOnOutOfMemoryError"
+                # If we run out of memory we want the JVM to die with error code 134
+                export JAVA_OPTS="-XX:+CrashOnOutOfMemoryError"
+                export %s_HOME=${%s_HOME:=/opt/%s/%s}
+                # This might get overridden by the tool home configuration above. This is
+                # useful if Gradle/Ant also requires Maven configured.
+                export MAVEN_HOME=${MAVEN_HOME:=/opt/maven/3.8.8}
+                export GRADLE_USER_HOME="${JBS_WORKDIR}/software/settings/.gradle"
+
+                mkdir -p ${JBS_WORKDIR}/logs ${JBS_WORKDIR}/packages ${HOME}/.sbt/1.0 ${GRADLE_USER_HOME} ${HOME}/.m2
+                cd ${JBS_WORKDIR}/source
+
+                if [ -n "${JAVA_HOME}" ]; then
+                    echo "JAVA_HOME:$JAVA_HOME"
+                    PATH="${JAVA_HOME}/bin:$PATH"
+                fi
+
+                if [ -n "${MAVEN_HOME}" ]; then
+                """.formatted(javaHome, type.name(), type.name(), type, buildToolVersion);
+
+        runBuild += getMavenSetup();
+
+        runBuild += """
+                fi
+
+                if [ -n "${GRADLE_HOME}" ]; then
+                """;
+
+        runBuild += getGradleSetup();
+
+        runBuild += """
+                fi
+
+                if [ -n "${ANT_HOME}" ]; then
+                """;
+
+        runBuild += getAntSetup();
+
+        runBuild += """
+                fi
+
+                if [ -n "${SBT_HOME}" ]; then
+                """;
+
+        runBuild += getSbtSetup();
+
+        runBuild += """
+                fi
+                echo "PATH:$PATH"
+
+                update-ca-trust
+
+                # Go through certificates and insert them into the cacerts
+                for cert in $(find /etc/pki/ca-trust/source/anchors -type f); do
+                  echo "Inserting $cert into java cacerts"
+                  keytool -import -alias $(basename $cert)-ca \\
+                    -file $cert \\
+                    -keystore /etc/pki/java/cacerts \\
+                    -storepass changeit --noprompt
+                done
+
+                # End of generic build script
+
+                echo "Building the project ..."
+                """;
+
+        if (isNotEmpty(buildScript)) {
+            // Now add in the build script from either JBS or PNC. This might contain e.g. "mvn -Pfoo install"
+            runBuild += buildScript;
+        }
+        Log.debugf("### runBuild is\n%s", runBuild);
+
+        try {
+            Path runBuildSh = Paths.get(jbsDirectory.toString(), "run-build.sh");
+            Files.writeString(runBuildSh, runBuild);
+            //noinspection ResultOfMethodCallIgnored
+            runBuildSh.toFile().setExecutable(true);
+            Files.writeString(Paths.get(jbsDirectory.toString(), "Containerfile"), getContainerFile());
+        } catch (IOException e) {
+            Log.errorf("Unable to write Containerfile", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getContainerFile() {
+        String containerFile = """
+                FROM %s
+                USER 0
+                WORKDIR /var/workdir
+                ARG PROXY_URL=""
+                ENV PROXY_URL=$PROXY_URL
+                COPY .jbs/run-build.sh /var/workdir
+                COPY . /var/workdir/workspace/source/
+                RUN /var/workdir/run-build.sh 2>&1 | tee /var/workdir/build.log
+                """.formatted(recipeImage);
+
+        if (type == ToolType.ANT) {
+            // Don't think we need to mess with keystore as copy-artifacts is simply calling copy commands.
+            containerFile += """
+                    FROM %s AS build-request-processor
+                    USER 0
+                    WORKDIR /var/workdir
+                    COPY --from=0 /var/workdir/ /var/workdir/
+                    RUN /opt/jboss/container/java/run/run-java.sh copy-artifacts --source-path=/var/workdir/workspace/source --deploy-path=/var/workdir/workspace/artifacts
+                    FROM scratch
+                    COPY --from=1 /var/workdir/workspace/artifacts /deployment/
+                    COPY --from=1 /var/workdir/build.log /log/
+                    """
+                    .formatted(buildRequestProcessorImage);
+        } else {
+            containerFile += """
+                    FROM scratch
+                    COPY --from=0 /var/workdir/workspace/artifacts /deployment/
+                    COPY --from=0 /var/workdir/build.log /log/
+                    """;
+        }
+
+        return containerFile;
+    }
+
+    /**
+     * This will generate the settings and toolchain into the standard $HOME/.m2 location and configure
+     * altDeploymentDirectory to be used by default.
+     */
+    private String getMavenSetup() {
+
+        return """
+                    echo "MAVEN_HOME:$MAVEN_HOME"
+                    PATH="${MAVEN_HOME}/bin:$PATH"
+
+                    if [ ! -d "${MAVEN_HOME}" ]; then
+                        echo "Maven home directory not found at ${MAVEN_HOME}" >&2
+                        exit 1
+                    fi
+
+                    if [ -n "${PROXY_URL}" ]; then
+                    cat >${HOME}/.m2/settings.xml <<EOF
+                <settings>
+                  <mirrors>
+                    <mirror>
+                      <id>indy-mvn</id>
+                      <url>${PROXY_URL}</url>
+                      <mirrorOf>*</mirrorOf>
+                    </mirror>
+                  </mirrors>
+                EOF
+                    else
+                        cat >${HOME}/.m2/settings.xml <<EOF
+                <settings>
+                EOF
+                    fi
+                    cat >>${HOME}/.m2/settings.xml <<EOF
+                  <!-- Allows a secondary Maven build to use results of prior (e.g. Gradle) deployment -->
+                  <profiles>
+                    <profile>
+                      <id>secondary</id>
+                      <repositories>
+                        <repository>
+                          <id>artifacts</id>
+                          <url>file://${JBS_WORKDIR}/artifacts</url>
+                          <releases>
+                            <enabled>true</enabled>
+                            <checksumPolicy>ignore</checksumPolicy>
+                          </releases>
+                        </repository>
+                      </repositories>
+                      <pluginRepositories>
+                        <pluginRepository>
+                          <id>artifacts</id>
+                          <url>file://${JBS_WORKDIR}/artifacts</url>
+                          <releases>
+                            <enabled>true</enabled>
+                            <checksumPolicy>ignore</checksumPolicy>
+                          </releases>
+                        </pluginRepository>
+                      </pluginRepositories>
+                    </profile>
+                    <profile>
+                      <id>local-deployment</id>
+                      <properties>
+                        <altDeploymentRepository>
+                          local::file://${JBS_WORKDIR}/artifacts
+                        </altDeploymentRepository>
+                      </properties>
+                    </profile>
+                  </profiles>
+
+                  <activeProfiles>
+                    <activeProfile>secondary</activeProfile>
+                    <activeProfile>local-deployment</activeProfile>
+                  </activeProfiles>
+
+                  <interactiveMode>false</interactiveMode>
+
+                  <proxies>
+                    <proxy>
+                      <id>indy-http</id>
+                      <!-- TODO: Until domain-proxy is implemented disable this - probably needs conditional activation but settings profiles don't support interpolation -->
+                      <active>false</active>
+                      <protocol>http</protocol>
+                      <host>domain-proxy</host>
+                      <port>80</port>
+                      <!-- <username>build-ADDTW3JAGHYAA+tracking</username> -->
+                      <username>${BUILD_ID}+tracking</username>
+                      <password>${ACCESS_TOKEN}</password>
+                      <nonProxyHosts>${PROXY_URL}|localhost</nonProxyHosts>
+                    </proxy>
+                    <proxy>
+                      <id>indy-https</id>
+                      <active>false</active>
+                      <protocol>https</protocol>
+                      <host>domain-proxy</host>
+                      <port>80</port>
+                      <username>${BUILD_ID}+tracking</username>
+                      <password>${ACCESS_TOKEN}</password>
+                      <nonProxyHosts>${PROXY_URL}|localhost</nonProxyHosts>
+                    </proxy>
+                  </proxies>
+
+                </settings>
+                EOF
+
+                    TOOLCHAINS_XML=${HOME}/.m2/toolchains.xml
+
+                    cat >"$TOOLCHAINS_XML" <<EOF
+                <?xml version="1.0" encoding="UTF-8"?>
+                <toolchains>
+                EOF
+
+                    if [ "%s" = "7" ]; then
+                        JAVA_VERSIONS="7:1.7.0 8:1.8.0 11:11"
+                    else
+                        JAVA_VERSIONS="8:1.8.0 9:11 11:11 17:17 21:21 22:23 23:23"
+                    fi
+
+                    for i in $JAVA_VERSIONS; do
+                        version=$(echo $i | cut -d : -f 1)
+                        home=$(echo $i | cut -d : -f 2)
+                        cat >>"$TOOLCHAINS_XML" <<EOF
+                  <toolchain>
+                    <type>jdk</type>
+                    <provides>
+                      <version>$version</version>
+                    </provides>
+                    <configuration>
+                      <jdkHome>/usr/lib/jvm/java-$home-openjdk</jdkHome>
+                    </configuration>
+                  </toolchain>
+                EOF
+                    done
+
+                    cat >>"$TOOLCHAINS_XML" <<EOF
+                </toolchains>
+                EOF
+                """
+                .formatted(javaVersion);
+    }
+
+    private String getGradleSetup() {
+        return """
+                    echo "GRADLE_HOME:$GRADLE_HOME"
+                    PATH="${GRADLE_HOME}/bin:$PATH"
+
+                    if [ ! -d "${GRADLE_HOME}" ]; then
+                        echo "Gradle home directory not found at ${GRADLE_HOME}" >&2
+                        exit 1
+                    fi
+
+                    cat > "${GRADLE_USER_HOME}"/gradle.properties << EOF
+                org.gradle.console=plain
+
+                # Increase timeouts
+                systemProp.org.gradle.internal.http.connectionTimeout=600000
+                systemProp.org.gradle.internal.http.socketTimeout=600000
+                systemProp.http.socketTimeout=600000
+                systemProp.http.connectionTimeout=600000
+
+                # Settings for <https://github.com/vanniktech/gradle-maven-publish-plugin>
+                RELEASE_REPOSITORY_URL=file://${JBS_WORKDIR}/artifacts
+                RELEASE_SIGNING_ENABLED=false
+                mavenCentralUsername=
+                mavenCentralPassword=
+
+                # Default values for common enforced properties
+                sonatypeUsername=jbs
+                sonatypePassword=jbs
+
+                # Default deployment target
+                # https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_system_properties
+                systemProp.maven.repo.local=${JBS_WORKDIR}/artifacts
+                EOF
+                """;
+    }
+
+    private String getAntSetup() {
+        return """
+                    echo "ANT_HOME:$ANT_HOME"
+                    PATH="${ANT_HOME}/bin:$PATH"
+
+                    if [ ! -d "${ANT_HOME}" ]; then
+                        echo "Ant home directory not found at ${ANT_HOME}" >&2
+                        exit 1
+                    fi
+
+                    if [ -n "${PROXY_URL}" ]; then
+                        cat > ivysettings.xml << EOF
+                <ivysettings>
+                    <property name="cache-url" value="${PROXY_URL}"/>
+                    <property name="default-pattern" value="[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"/>
+                    <property name="local-pattern" value="\\${user.home}/.m2/repository/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"/>
+                    <settings defaultResolver="defaultChain"/>
+                    <resolvers>
+                        <ibiblio name="default" root="\\${cache-url}" pattern="\\${default-pattern}" m2compatible="true"/>
+                        <filesystem name="local" m2compatible="true">
+                            <artifact pattern="\\${local-pattern}"/>
+                            <ivy pattern="\\${local-pattern}"/>
+                        </filesystem>
+                        <chain name="defaultChain">
+                            <resolver ref="local"/>
+                            <resolver ref="default"/>
+                        </chain>
+                    </resolvers>
+                </ivysettings>
+                EOF
+                    fi
+                """;
+    }
+
+    private String getSbtSetup() {
+        return """
+                echo "SBT_HOME:$SBT_HOME"
+                PATH="${SBT_HOME}/bin:$PATH"
+
+                if [ ! -d "${SBT_HOME}" ]; then
+                echo "SBT home directory not found at ${SBT_HOME}" >&2
+                exit 1
+                fi
+
+                if [ -n "${PROXY_URL}" ]; then
+                cat > "${HOME}/.sbt/repositories" <<EOF
+                    [repositories]
+                local
+                my-maven-proxy-releases: ${PROXY_URL}
+                EOF
+                    fi
+                        # TODO: we may need .allowInsecureProtocols here for minikube based tests that don't have access to SSL
+                cat >"$HOME/.sbt/1.0/global.sbt" <<EOF
+                publishTo := Some(("MavenRepo" at s"file:${JBS_WORKDIR}/artifacts")),
+                EOF
+                """;
+    }
+}

--- a/src/test/java/org/jboss/pnc/konfluxtooling/deploy/MavenDeployTest.java
+++ b/src/test/java/org/jboss/pnc/konfluxtooling/deploy/MavenDeployTest.java
@@ -1,0 +1,138 @@
+package org.jboss.pnc.konfluxtooling.deploy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
+import io.quarkus.test.LogCollectingTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "FINE"))
+public class MavenDeployTest {
+    private static final String GROUP = "com.company.foo";
+    private static final String VERSION = "3.25.8";
+    public static final String FOO_BAR = "foo-bar";
+    public static final String FOO_BAZ = "foo-baz";
+    private static final String DOT = ".";
+    private static final String SHA_1 = "sha1";
+
+    // ArtifactName -> [ collection of Artifacts ]
+    private final Map<String, Set<String>> ARTIFACT_FILE_MAP = Map.of(
+            FOO_BAR, Set.of("foo-bar-" + VERSION + ".jar", "foo-bar-" + VERSION + "-tests.jar"),
+            FOO_BAZ, Set.of("foo-baz-" + VERSION + ".pom"));
+
+    @Inject
+    BootstrapMavenContext mvnContext;
+
+    @BeforeEach
+    public void clearLogs() {
+        LogCollectingTestResource.current().clear();
+    }
+
+    @Test
+    public void testDeploy() throws IOException {
+        Path onDiskRepo = createDeploymentRepo();
+        Path source = Files.createTempDirectory("hacbs");
+        Path deployment = Files.createTempDirectory("deployment");
+        Files.writeString(source.resolve("pom.xml"), "");
+
+        DeployCommand deployCommand = new DeployCommand();
+        deployCommand.mvnCtx = mvnContext;
+        deployCommand.mvnPassword = Optional.empty();
+        deployCommand.accessToken = Optional.empty();
+        deployCommand.mvnRepo = deployment.toAbsolutePath().toUri().toString();
+        deployCommand.artifactDirectory = onDiskRepo.toString();
+
+        deployCommand.run();
+        List<LogRecord> logRecords = LogCollectingTestResource.current().getRecords();
+
+        assertTrue(logRecords.stream()
+                .anyMatch(r -> LogCollectingTestResource.format(r).contains("no pom file found with files")));
+        assertTrue(logRecords.stream().anyMatch(r -> LogCollectingTestResource.format(r)
+                .contains("Deploying [com.company.foo:foo-baz:pom:3.25.8]")));
+        assertTrue(logRecords.stream().anyMatch(r -> LogCollectingTestResource.format(r)
+                .contains(
+                        "Deploying [com.company.foo:foo-bar:jar:tests:3.25.8, com.company.foo:foo-bar:jar:3.25.8, com.company.foo:foo-bar:pom:3.25.8]")));
+
+        File[] files = Paths.get(deployment.toString(), "com/company/foo/foo-bar/3.25.8").toFile().listFiles();
+        assertNotNull(files);
+        assertEquals(9, files.length);
+    }
+
+    private Path createDeploymentRepo()
+            throws IOException {
+        Path testData = Files.createTempDirectory("test-data");
+        Path artifacts = Paths.get(testData.toString(), "artifacts").toAbsolutePath();
+        Files.createDirectories(artifacts);
+
+        Files.createFile(Paths.get(artifacts.toString(), "test-file.txt"));
+
+        // Add data to artifacts folder
+        for (Map.Entry<String, Set<String>> artifactFiles : ARTIFACT_FILE_MAP.entrySet()) {
+            String groupPath = GROUP.replace(DOT, File.separator);
+            Path testDir = Paths.get(artifacts.toString(), groupPath, artifactFiles.getKey(),
+                    VERSION);
+            Files.createDirectories(testDir);
+            for (String value : artifactFiles.getValue()) {
+                Path testFile = Paths.get(testDir.toString(), value);
+                Files.createFile(testFile);
+                String testContent = "Just some data for " + artifactFiles.getKey();
+                Files.writeString(testFile, testContent);
+                Path shaFile = Paths.get(testFile + DOT + SHA_1);
+                Files.createFile(shaFile);
+                String sha1 = sha1(Files.readAllBytes(testFile));
+                Files.writeString(shaFile, sha1);
+            }
+            Optional<String> jarFile = artifactFiles.getValue().stream().filter(s -> s.endsWith(VERSION + ".jar")).findAny();
+            if (jarFile.isPresent()) {
+                Path pomFile = Paths.get(testDir.toString(), jarFile.get().replace(".jar", ".pom"));
+                Model model = new Model();
+                model.setArtifactId(artifactFiles.getKey());
+                model.setGroupId(GROUP);
+                model.setVersion(VERSION);
+                new MavenXpp3Writer().write(new FileWriter(pomFile.toFile()), model);
+            }
+        }
+        return artifacts;
+    }
+
+    public static String sha1(byte[] value) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            byte[] digest = md.digest(value);
+            StringBuilder sb = new StringBuilder(40);
+            for (int i = 0; i < digest.length; ++i) {
+                sb.append(Integer.toHexString((digest[i] & 0xFF) | 0x100).substring(1, 3));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/src/test/java/org/jboss/pnc/konfluxtooling/notification/NotificationTest.java
+++ b/src/test/java/org/jboss/pnc/konfluxtooling/notification/NotificationTest.java
@@ -1,0 +1,71 @@
+package org.jboss.pnc.konfluxtooling.notification;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.logging.LogRecord;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.pnc.api.constants.HttpHeaders;
+import org.jboss.pnc.api.dto.Request;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import io.quarkus.test.LogCollectingTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@QuarkusTestResource(value = LogCollectingTestResource.class, restrictToAnnotatedClass = true, initArgs = @ResourceArg(name = LogCollectingTestResource.LEVEL, value = "FINE"))
+@QuarkusTestResource(WireMockExtensions.class)
+public class NotificationTest {
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    public void clearLogs() {
+        LogCollectingTestResource.current().clear();
+    }
+
+    @Test
+    public void testNoNotify() {
+        NotifyCommand notifyCommand = new NotifyCommand();
+        notifyCommand.status = "Succeeded";
+        notifyCommand.buildId = "1234";
+        notifyCommand.run();
+        List<LogRecord> logRecords = LogCollectingTestResource.current().getRecords();
+        assertTrue(logRecords.stream()
+                .anyMatch(r -> LogCollectingTestResource.format(r).contains("No callback configured ; unable to notify")));
+    }
+
+    @Test
+    public void testNotify() throws IOException, URISyntaxException {
+
+        Request request = Request.builder()
+                .method(Request.Method.PUT)
+                .header(new Request.Header(HttpHeaders.CONTENT_TYPE_STRING, MediaType.APPLICATION_JSON))
+                .attachment(null)
+                .uri(new URI(wireMockServer.baseUrl() + "/internal/completed"))
+                .build();
+
+        NotifyCommand notifyCommand = new NotifyCommand();
+        notifyCommand.status = "Succeeded";
+        notifyCommand.buildId = "1234";
+        notifyCommand.objectMapper = new ObjectMapper();
+        notifyCommand.context = notifyCommand.objectMapper.writeValueAsString(request);
+        notifyCommand.run();
+
+        List<LogRecord> logRecords = LogCollectingTestResource.current().getRecords();
+        assertTrue(logRecords.stream()
+                .anyMatch(r -> LogCollectingTestResource.format(r)
+                        .contains("Response (PUT http://localhost:8080/internal/completed) 200")));
+    }
+}

--- a/src/test/java/org/jboss/pnc/konfluxtooling/notification/WireMockExtensions.java
+++ b/src/test/java/org/jboss/pnc/konfluxtooling/notification/WireMockExtensions.java
@@ -1,0 +1,45 @@
+package org.jboss.pnc.konfluxtooling.notification;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class WireMockExtensions implements QuarkusTestResourceLifecycleManager {
+    private WireMockServer wireMockServer;
+
+    @Override
+    public Map<String, String> start() {
+        wireMockServer = new WireMockServer(wireMockConfig().notifier(new ConsoleNotifier(true)));
+        wireMockServer.start();
+
+        wireMockServer.stubFor(
+                put(urlEqualTo("/internal/completed"))
+                        .withRequestBody(
+                                equalToJson("{\"status\":\"Succeeded\",\"buildId\":\"1234\",\"completionCallback\":null}"))
+                        .willReturn(aResponse()
+                                .withStatus(200)));
+
+        return Map.of("quarkus.rest-client.wiremockextensions.url", wireMockServer.baseUrl());
+    }
+
+    @Override
+    public void stop() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(wireMockServer, new TestInjector.MatchesType(WireMockServer.class));
+    }
+}


### PR DESCRIPTION
This contains a modified copy of the java-components/build-request-processor code from https://github.com/redhat-appstudio/jvm-build-service

Primary differences:

- It has been compressed to only copy what is needed for the custom pipeline (and not JBS) i.e. removing bytecode verification, analyser, pre-build source committing etc.
- Ability to modify build tooling plugins within the prepare phase has been removed and the prepare has been consolidated to only generating the build script and Containerfile.
