### PR TITLE
Adjust notification status to be an enum

### DIFF
--- a/src/main/java/org/jboss/pnc/konfluxtooling/notification/NotifyCommand.java
+++ b/src/main/java/org/jboss/pnc/konfluxtooling/notification/NotifyCommand.java
@@ -12,11 +12,12 @@ import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.pnc.api.dto.Request;
+import org.jboss.pnc.api.konfluxbuilddriver.dto.PipelineNotification;
+import org.jboss.pnc.api.konfluxbuilddriver.dto.PipelineStatus;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.logging.Log;
-import org.jboss.pnc.api.konfluxbuilddriver.dto.PipelineNotification;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "notify")
@@ -25,8 +26,8 @@ public class NotifyCommand implements Runnable {
     @CommandLine.Option(names = "--build-id", required = true)
     String buildId;
 
-    @CommandLine.Option(names = "--status", required = true)
-    String status;
+    @CommandLine.Option(names = "--status", description = "Valid values: ${COMPLETION-CANDIDATES}", required = true)
+    PipelineStatus status;
 
     @CommandLine.Option(names = "--context", required = true)
     String context;

--- a/src/test/java/org/jboss/pnc/konfluxtooling/notification/NotificationTest.java
+++ b/src/test/java/org/jboss/pnc/konfluxtooling/notification/NotificationTest.java
@@ -12,6 +12,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.jboss.pnc.api.constants.HttpHeaders;
 import org.jboss.pnc.api.dto.Request;
+import org.jboss.pnc.api.konfluxbuilddriver.dto.PipelineStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +42,7 @@ public class NotificationTest {
     @Test
     public void testNoNotify() {
         NotifyCommand notifyCommand = new NotifyCommand();
-        notifyCommand.status = "Succeeded";
+        notifyCommand.status = PipelineStatus.Succeeded;
         notifyCommand.buildId = "1234";
         notifyCommand.run();
         List<LogRecord> logRecords = LogCollectingTestResource.current().getRecords();
@@ -63,7 +64,7 @@ public class NotificationTest {
                 .build();
 
         NotifyCommand notifyCommand = new NotifyCommand();
-        notifyCommand.status = "Succeeded";
+        notifyCommand.status = PipelineStatus.Succeeded;
         notifyCommand.buildId = "1234";
         notifyCommand.objectMapper = new ObjectMapper();
         notifyCommand.context = notifyCommand.objectMapper.writeValueAsString(request);


### PR DESCRIPTION
The new enum type is `PipelineStatus`.

This is related to the change here: https://github.com/project-ncl/pnc-api/commit/6ac111af39d6542b48c3ceb24b5b3097234fab33